### PR TITLE
Remove lower bounds on fmt/spdlog to use global conda-forge pins

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11.2'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -21,6 +23,8 @@ python:
 - 3.11.* *_cpython
 - 3.12.* *_cpython
 - 3.13.* *_cp313
+spdlog:
+- '1.15'
 target_platform:
 - linux-64
 tiledb:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11.2'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -21,6 +23,8 @@ python:
 - 3.11.* *_cpython
 - 3.12.* *_cpython
 - 3.13.* *_cp313
+spdlog:
+- '1.15'
 target_platform:
 - linux-aarch64
 tiledb:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '14'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11.2'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -21,6 +23,8 @@ python:
 - 3.11.* *_cpython
 - 3.12.* *_cpython
 - 3.13.* *_cp313
+spdlog:
+- '1.15'
 target_platform:
 - linux-ppc64le
 tiledb:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+fmt:
+- '11.2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -25,6 +27,8 @@ python:
 - 3.11.* *_cpython
 - 3.12.* *_cpython
 - 3.13.* *_cp313
+spdlog:
+- '1.15'
 target_platform:
 - osx-64
 tiledb:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
+fmt:
+- '11.2'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:
@@ -25,6 +27,8 @@ python:
 - 3.11.* *_cpython
 - 3.12.* *_cpython
 - 3.13.* *_cp313
+spdlog:
+- '1.15'
 target_platform:
 - osx-arm64
 tiledb:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
     - include-thread-pool.patch
 
 build:
-  number: 0
+  number: 1
   skip: win
 
 outputs:
@@ -55,8 +55,8 @@ outputs:
         - pkg-config
       host:
         - tiledb
-        - spdlog >=1.15
-        - fmt >=11.0
+        - spdlog
+        - fmt
       run_exports:
         - ${{ pin_subpackage('libtiledbsoma', exact=True) }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

fmt/spdlog are [globally pinned by conda-forge](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml). In order to use the same pins as the rest of the ecosystem and receive automated migration PRs, I removed the lower bounds from the recipe.

xref: https://github.com/conda-forge/tiledbsoma-feedstock/pull/20#issuecomment-3416132211, https://github.com/conda-forge/tiledb-feedstock/pull/465